### PR TITLE
Test/gx3-3643/tools_qa_elements_buttons

### DIFF
--- a/coverage/in-sprint/sprint-43/GX3-3643.md
+++ b/coverage/in-sprint/sprint-43/GX3-3643.md
@@ -1,22 +1,12 @@
 
 Expected actions
-
 Buttons:
-
  Button ( Double Click ):
-
 IF: “Double Click” button is clicked
-
 Then : In the ClickMessage section, a message must be displayed as: ( “You have done a double click” )
-
 Button ( Right Click ) :
-
 IF: “*Right Click”* button is clicked
-
 Then : In the ClickMessage section, a message must be displayed as: ( “You have done a right click” )
-
 Button ( Click ):
-
 IF: “*Click”* button is clicked
-
 Then : In the ClickMessage section, a message must be displayed as: ( “You have done a dynamic click” )

--- a/tests/specs/elements/button_GX3_3643.test.ts
+++ b/tests/specs/elements/button_GX3_3643.test.ts
@@ -1,37 +1,32 @@
-import {test} from '@pages/TestBase';
+import { test } from '@pages/TestBase';
 import { expect } from '@playwright/test';
 
-		test.describe('GX3-3643:ToolsQA|Elements|Buttons',()=>{
-		test.beforeEach( async({page})=>{
-			await page.goto('https://demoqa.com/buttons', {waitUntil:'domcontentloaded'})
-		})
+test.describe('GX3-3643:ToolsQA|Elements|Buttons', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('https://demoqa.com/buttons', { waitUntil: 'domcontentloaded' });
+	});
 
+	test('TC1: Validar hacer click en el botón doble click', async ({ page }) => {
+		const doubleClickBtn = page.locator('#doubleClickBtn');
+		await doubleClickBtn.dblclick();
+		var doubleClickMessage = page.locator('#doubleClickMessage');
+		await expect(doubleClickMessage).toBeVisible();
+		await expect(doubleClickMessage).toHaveText('You have done a double click');
+	});
 
-		test('TC1: Validar hacer click en el botón doble click',async({page})=>{
-			const doubleClickBtn = page.locator('#doubleClickBtn')
-			await doubleClickBtn.dblclick()
-			var doubleClickMessage=page.locator('#doubleClickMessage')
-			expect(doubleClickMessage).toBeVisible()
-			expect(doubleClickMessage).toHaveText('You have done a double click')
+	test('TC2:Realizar click en el botón Right Click', async ({ page }) => {
+		const rightClickBtn = page.locator('#rightClickBtn');
+		await rightClickBtn.click({ button: 'right' });
+		var rightClickMessage = page.locator('#rightClickMessage');
+		await expect(rightClickMessage).toBeVisible();
+		await expect(rightClickMessage).toHaveText('You have done a right click');
+	});
 
-		})
-
-		test('TC2:Realizar click en el botón Right Click', async({ page })=>{
-			const rightClickBtn = page.locator('#rightClickBtn')
-			await rightClickBtn.click({button:'right'})
-			var rightClickMessage=page.locator('#rightClickMessage')
-			expect(rightClickMessage).toBeVisible()
-			expect(rightClickMessage).toHaveText('You have done a right click') 
-
-		})
-
-		test('TC3:Realizar click en el botón Click', async({ page })=>{
-			const clickBtn = page.getByText('Click Me', {exact:true})
-			await clickBtn.waitFor({state:'visible'})
-			await clickBtn.click();
-			var dynamicClickMessage=page.locator('#dynamicClickMessage')
-			expect(dynamicClickMessage).toHaveText('You have done a dynamic click')
-			
-		})
-
-})
+	test('TC3:Realizar click en el botón Click', async ({ page }) => {
+		const clickBtn = page.getByText('Click Me', { exact: true });
+		await clickBtn.waitFor({ state: 'visible' });
+		await clickBtn.click();
+		var dynamicClickMessage = page.locator('#dynamicClickMessage');
+		await expect(dynamicClickMessage).toHaveText('You have done a dynamic click');
+	});
+});

--- a/tests/specs/elements/button_GX3_3643.test.ts
+++ b/tests/specs/elements/button_GX3_3643.test.ts
@@ -5,7 +5,6 @@ test.describe('GX3-3643:ToolsQA|Elements|Buttons', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('https://demoqa.com/buttons', { waitUntil: 'domcontentloaded' });
 	});
-
 	test('TC1: Validar hacer click en el botón doble click', async ({ page }) => {
 		const doubleClickBtn = page.locator('#doubleClickBtn');
 		await doubleClickBtn.dblclick();
@@ -13,7 +12,6 @@ test.describe('GX3-3643:ToolsQA|Elements|Buttons', () => {
 		await expect(doubleClickMessage).toBeVisible();
 		await expect(doubleClickMessage).toHaveText('You have done a double click');
 	});
-
 	test('TC2:Realizar click en el botón Right Click', async ({ page }) => {
 		const rightClickBtn = page.locator('#rightClickBtn');
 		await rightClickBtn.click({ button: 'right' });
@@ -21,7 +19,6 @@ test.describe('GX3-3643:ToolsQA|Elements|Buttons', () => {
 		await expect(rightClickMessage).toBeVisible();
 		await expect(rightClickMessage).toHaveText('You have done a right click');
 	});
-
 	test('TC3:Realizar click en el botón Click', async ({ page }) => {
 		const clickBtn = page.getByText('Click Me', { exact: true });
 		await clickBtn.waitFor({ state: 'visible' });


### PR DESCRIPTION
Summary changes:

the funcionality of buttons of toolsQA was tested.
three TCs were design and automated

3644 | TC1: Validar hacer click en el botón “Double Click“
3644 | TC2: Validar hacer click en el botón “Right Click“
3644 | TC3: Validar hacer click en el botón “Click”

Tests results

![image](https://github.com/upex-galaxy/playwright-blackhole/assets/128328849/1d31c3b1-6370-4414-bf15-06af29c80a1b)


All clicks in every button were verify and the messages displayed.
All test cases pass.

Observations:

This PR is for blackhole Course